### PR TITLE
Add Terms of Use page

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -164,33 +164,6 @@ Here's a list of example actions that you can do using the API:
 * :doc:`Operate your locks <howtos/operate-locks>`
 * :doc:`Update lock settings <howtos/update-lock-settings>`
 
-Legal notice
-------------
 
-The following legal terms (“Legal Notice”) apply to all use of Tedee’s API. By accessing or using our API, you agree to these terms in full.
-
-**1. NO WARRANTIES; “AS-IS” BASIS**
-
-Tedee provides its API and all related content strictly on an “as-is” and “as-available” basis. To the fullest extent permitted by applicable law, Tedee disclaims all representations and warranties of any kind, whether express, implied, statutory or otherwise - including, without limitation, warranties of title, non-infringement, merchantability, fitness for a particular purpose, uninterrupted availability, accuracy, or those arising from course of dealing or usage of trade.
- 
-**2. LIMITATION OF LIABILITY**
-
-Under no circumstances shall Tedee, its affiliates, officers, directors, employees or agents be liable for any indirect, incidental, special, consequential, punitive or exemplary damages—including, without limitation, lost profits, lost revenue, loss of data or business interruption—arising out of or in connection with your use of, or inability to use, the APIs, even if Tedee has been advised of the possibility of such damages.
- 
-To the maximum extent permitted by law, Tedee’s total liability for any claim arising from or related to these APIs, whether in contract, tort (including negligence), strict liability or otherwise, is limited to the greater of (a) the fees you have actually paid to Tedee for use of the applicable API during the six months immediately preceding the event giving rise to liability, or (b) the re-supply of the API.
- 
-**3. INDEMNIFICATION**
-
-You agree to defend, indemnify and hold harmless Tedee and its affiliates, officers, directors, employees and agents from and against any and all liabilities, damages, losses, claims, costs and expenses (including reasonable legal fees) arising out of or relating to: Your use of, or inability to use, the API; Your breach of this Legal Notice or any other agreement with Tedee; or Any content, data or materials you transmit to or through the API.
-
-**4. THIRD-PARTY CONTENT & SERVICES**
-
-The API may expose content or services owned by third parties. Tedee makes no representations or warranties whatsoever regarding the legality, accuracy, copyright compliance, or quality of any such third-party content or services. You bear all risks associated with your access to and use of third-party content through the API.
- 
-**5. REGULATORY COMPLIANCE**
-
-You are solely responsible for ensuring your use of the APIs complies with all applicable laws, regulations, export controls, and third-party rights (including without limitation privacy, data protection, and intellectual property rights).
- 
-**6. MODIFICATIONS; TERMINATION**
-
-Tedee may modify or discontinue, temporarily or permanently, all or part of the API at any time and without notice. You agree that Tedee will not be liable to you or any third party for any modification, suspension, or discontinuation of the API.
+.. note::
+   By using this API, you agree to the :doc:`Terms of Use <terms-of-use>`.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,6 +16,7 @@ Tedee API documentation
    api-rate-limiting
    logo-guidance
    release-notes
+   terms-of-use
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/terms-of-use.rst
+++ b/docs/source/terms-of-use.rst
@@ -1,0 +1,33 @@
+Terms of Use
+===========
+
+Legal notice
+------------
+
+The following legal terms (“Legal Notice”) apply to all use of Tedee’s API. By accessing or using our API, you agree to these terms in full.
+
+**1. NO WARRANTIES; “AS-IS” BASIS**
+
+Tedee provides its API and all related content strictly on an “as-is” and “as-available” basis. To the fullest extent permitted by applicable law, Tedee disclaims all representations and warranties of any kind, whether express, implied, statutory or otherwise - including, without limitation, warranties of title, non-infringement, merchantability, fitness for a particular purpose, uninterrupted availability, accuracy, or those arising from course of dealing or usage of trade.
+ 
+**2. LIMITATION OF LIABILITY**
+
+Under no circumstances shall Tedee, its affiliates, officers, directors, employees or agents be liable for any indirect, incidental, special, consequential, punitive or exemplary damages—including, without limitation, lost profits, lost revenue, loss of data or business interruption—arising out of or in connection with your use of, or inability to use, the APIs, even if Tedee has been advised of the possibility of such damages.
+ 
+To the maximum extent permitted by law, Tedee’s total liability for any claim arising from or related to these APIs, whether in contract, tort (including negligence), strict liability or otherwise, is limited to the greater of (a) the fees you have actually paid to Tedee for use of the applicable API during the six months immediately preceding the event giving rise to liability, or (b) the re-supply of the API.
+ 
+**3. INDEMNIFICATION**
+
+You agree to defend, indemnify and hold harmless Tedee and its affiliates, officers, directors, employees and agents from and against any and all liabilities, damages, losses, claims, costs and expenses (including reasonable legal fees) arising out of or relating to: Your use of, or inability to use, the API; Your breach of this Legal Notice or any other agreement with Tedee; or Any content, data or materials you transmit to or through the API.
+
+**4. THIRD-PARTY CONTENT & SERVICES**
+
+The API may expose content or services owned by third parties. Tedee makes no representations or warranties whatsoever regarding the legality, accuracy, copyright compliance, or quality of any such third-party content or services. You bear all risks associated with your access to and use of third-party content through the API.
+ 
+**5. REGULATORY COMPLIANCE**
+
+You are solely responsible for ensuring your use of the APIs complies with all applicable laws, regulations, export controls, and third-party rights (including without limitation privacy, data protection, and intellectual property rights).
+ 
+**6. MODIFICATIONS; TERMINATION**
+
+Tedee may modify or discontinue, temporarily or permanently, all or part of the API at any time and without notice. You agree that Tedee will not be liable to you or any third party for any modification, suspension, or discontinuation of the API.


### PR DESCRIPTION
## Summary
- move legal notice from Getting Started to new Terms of Use page
- reference Terms of Use from Getting Started
- expose Terms of Use page in documentation navigation

## Testing
- `make -C docs html` *(fails: sphinx-build not found)*

------
https://chatgpt.com/codex/tasks/task_b_6850182089ec832f860e602e905db86a